### PR TITLE
Remove variável KPI icon

### DIFF
--- a/script.js
+++ b/script.js
@@ -2966,10 +2966,13 @@ function renderResumoKPI(summary, context = {}) {
     const fillTarget = pct100.toFixed(2);
     const atgTitle = buildTitle("Atingidos", fmtType, atingidos, visibleAting);
     const totTitle = buildTitle("Total", fmtType, total, visibleTotal);
+    const iconMarkup = iconClass
+      ? `
+          <span class="kpi-icon"><i class="${iconClass}"></i></span>`
+      : "";
     return `
       <div class="kpi-pill">
-        <div class="kpi-strip__main">
-          <span class="kpi-icon"><i class="${iconClass}"></i></span>
+        <div class="kpi-strip__main">${iconMarkup}
           <div class="kpi-strip__text">
             <span class="kpi-strip__label" title="${titulo}">${titulo}</span>
             <div class="kpi-strip__stats">
@@ -2988,7 +2991,7 @@ function renderResumoKPI(summary, context = {}) {
   kpi.innerHTML = [
     buildCard("Indicadores", "ti ti-list-check", indicadoresAtingidos, indicadoresTotal, "int", visibleItemsHitCount),
     buildCard("Pontos", "ti ti-medal", pontosAtingidos, pontosTotal, "int", visiblePointsHit),
-    buildCard("Variável", "ti ti-cash", varAtingidoBase, varTotalBase, "brl", visibleVarAtingido, visibleVarMeta)
+    buildCard("Variável", null, varAtingidoBase, varTotalBase, "brl", visibleVarAtingido, visibleVarMeta)
   ].join("");
 
   triggerBarAnimation(kpi.querySelectorAll('.hitbar'), shouldAnimateResumo);


### PR DESCRIPTION
## Summary
- avoid rendering the KPI icon markup when no icon class is provided
- stop passing an icon class to the "Variável" KPI so only the progress bar is displayed

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3373a8188833187afec4357ff62fe