### PR TITLE
Atualizar logo Omega para PNG

### DIFF
--- a/omega.html
+++ b/omega.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Omega • Central de chamados</title>
-  <link rel="icon" type="image/svg+xml" href="img/omega-logo.svg"/>
-  <link rel="apple-touch-icon" href="img/omega-logo.svg" sizes="180x180"/>
-  <link rel="shortcut icon" href="img/omega-logo.svg"/>
+  <link rel="icon" type="image/png" href="img/logo-omega.png"/>
+  <link rel="apple-touch-icon" href="img/logo-omega.png" sizes="180x180"/>
+  <link rel="shortcut icon" href="img/logo-omega.png"/>
   <link href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="style.css"/>
@@ -18,7 +18,7 @@
     <section class="omega-modal__panel" role="dialog" aria-modal="true" aria-labelledby="omega-title">
       <header class="omega-header">
         <div class="omega-header__left">
-          <img class="omega-logo" src="img/omega-logo.svg" alt="Logotipo da Omega" width="48" height="48"/>
+          <img class="omega-logo" src="img/logo-omega.png" alt="Logotipo da Omega" width="48" height="48"/>
           <div class="omega-header__titles">
             <h2 id="omega-title">Central de chamados Omega</h2>
             <p id="omega-subtitle">Registre ocorrências e acompanhe atendimentos.</p>


### PR DESCRIPTION
## Summary
- update Omega favicon links to use the new logo-omega.png asset
- swap the modal logo to reference logo-omega.png

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d8c77c0d4c8331a75a092a4caa4da7