### PR TITLE
Adjust Omega layout spacing for sidebar toggle and list

### DIFF
--- a/omega.css
+++ b/omega.css
@@ -288,7 +288,6 @@ body.has-omega-open{ overflow:hidden; }
   border:none;
   border-radius:0;
   background:transparent;
-  box-shadow:-1px 0 0 rgba(213,219,234,.9);
   color:#1f2a44;
   display:flex;
   align-items:center;
@@ -436,7 +435,7 @@ body.has-omega-open{ overflow:hidden; }
   background:#fff;
   border-radius:18px;
   border:1px solid #e2e8f0;
-  padding:18px 22px;
+  padding:12px 18px;
   box-shadow:0 12px 34px rgba(15,20,36,.08);
 }
 .omega-toolbar__actions{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
@@ -591,7 +590,7 @@ body.has-omega-open{ overflow:hidden; }
   overflow:auto;
   background:#fff;
   box-shadow:0 20px 46px rgba(15,20,36,.12);
-  min-height:min(540px, 70vh);
+  min-height:max(640px, 70vh);
 }
 
 .omega-table{ width:100%; border-collapse:collapse; min-width:920px; }


### PR DESCRIPTION
## Summary
- remove the dividing line beside the sidebar chevron so the avatar frame stays intact
- reduce toolbar padding to free additional vertical room for the ticket content
- raise the ticket table's minimum height so roughly ten items are visible before scrolling

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9f417e76c8331b4e8301956a87893