### PR TITLE
Expose Omega notifications and allow full-height ticket table

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,16 @@
     </div>
 
     <div class="topbar__right">
+      <div class="topbar__notifications">
+        <button id="btn-topbar-notifications" class="topbar__bell" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="topbar-notification-panel">
+          <i class="ti ti-bell" aria-hidden="true"></i>
+          <span id="topbar-notification-badge" class="topbar__badge" hidden>0</span>
+          <span class="sr-only">Abrir notificações</span>
+        </button>
+        <div id="topbar-notification-panel" class="topbar-notification-panel" role="menu" aria-hidden="true">
+          <p class="topbar-notification-panel__empty">Nenhuma notificação no momento.</p>
+        </div>
+      </div>
       <div class="userbox">
         <button class="userbox__trigger" id="btn-user-menu" type="button" aria-haspopup="true" aria-expanded="false">
           <img class="userbox__avatar" src="https://i.pravatar.cc/80?img=12" alt="Foto do usuário"/>

--- a/omega.css
+++ b/omega.css
@@ -42,12 +42,16 @@ body.omega-standalone .omega-modal__panel{
   height:auto;
   min-height:calc(100vh - 40px);
   box-shadow:0 24px 60px rgba(15,20,36,.16);
+  max-height:none;
+  overflow:visible;
 }
 
 @media (max-width: 768px){
   body.omega-standalone #omega-modal{ padding:28px 12px; }
   body.omega-standalone .omega-modal__panel{ min-height:calc(100vh - 56px); border-radius:20px; }
 }
+
+body.omega-standalone .omega-main{ overflow:visible; padding-bottom:40px; }
 
 body.has-omega-open{ overflow:hidden; }
 
@@ -144,7 +148,7 @@ body.has-omega-open{ overflow:hidden; }
 .omega-header__titles p{ margin:0; color:var(--muted); font-size:12px; }
 
 .omega-header__actions{ display:flex; align-items:center; gap:8px; }
-.omega-notification-center{ position:relative; display:none; }
+.omega-notification-center{ position:relative; display:inline-flex; align-items:center; }
 .omega-notification-badge{
   position:absolute;
   top:-4px;

--- a/script.js
+++ b/script.js
@@ -3803,6 +3803,59 @@ function setupUserMenu(){
   userMenuBound = true;
 }
 
+let topbarNotificationsBound = false;
+function setupTopbarNotifications(){
+  if (topbarNotificationsBound) return;
+  const trigger = document.getElementById("btn-topbar-notifications");
+  const panel = document.getElementById("topbar-notification-panel");
+  const badge = document.getElementById("topbar-notification-badge");
+  if (!trigger || !panel) return;
+
+  const closePanel = () => {
+    panel.setAttribute("aria-hidden", "true");
+    panel.hidden = true;
+    trigger.setAttribute("aria-expanded", "false");
+  };
+
+  const openPanel = () => {
+    panel.hidden = false;
+    panel.setAttribute("aria-hidden", "false");
+    trigger.setAttribute("aria-expanded", "true");
+  };
+
+  trigger.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const expanded = trigger.getAttribute("aria-expanded") === "true";
+    if (expanded) closePanel(); else openPanel();
+  });
+
+  document.addEventListener("click", (ev) => {
+    if (panel.contains(ev.target) || trigger.contains(ev.target)) return;
+    closePanel();
+  });
+
+  window.addEventListener("keydown", (ev) => {
+    if (ev.key === "Escape") closePanel();
+  });
+
+  const setBadge = (count) => {
+    if (!badge) return;
+    const safe = Number.isFinite(count) ? Math.max(0, count) : 0;
+    if (safe > 0) {
+      badge.textContent = safe > 99 ? "99+" : String(safe);
+      badge.hidden = false;
+    } else {
+      badge.hidden = true;
+    }
+  };
+
+  setBadge(0);
+  closePanel();
+  topbarNotificationsBound = true;
+  setupTopbarNotifications.setBadge = setBadge;
+}
+
 function initMobileCarousel(){
   const host = document.getElementById("mobile-carousel");
   if (!host) return;
@@ -9457,6 +9510,7 @@ async function loadCSVAuto(url) {
   enableSimpleTooltip();
   injectStyles();
   setupUserMenu();
+  setupTopbarNotifications();
   await loadBaseData();
   initCombos();
   bindEvents();

--- a/style.css
+++ b/style.css
@@ -55,7 +55,7 @@ img{ max-width:100%; display:block; }
 /* =========================================================
    TOPBAR
    ========================================================= */
-.topbar{
+.topbar{ 
   position: sticky; top:0; z-index:1100;
   display:flex; align-items:center; justify-content:space-between;
   gap:12px; padding:8px 12px;
@@ -63,6 +63,63 @@ img{ max-width:100%; display:block; }
   color:#fff; box-shadow:0 6px 16px rgba(179,0,0,.25);
 }
 .topbar__left,.topbar__right{ display:flex; align-items:center; gap:10px; min-width:0; }
+.topbar__notifications{ position:relative; display:flex; align-items:center; }
+.topbar__bell{
+  position:relative;
+  width:40px; height:40px;
+  border-radius:50%;
+  border:1px solid rgba(255,255,255,.35);
+  background:rgba(255,255,255,.14);
+  color:#fff;
+  display:inline-flex; align-items:center; justify-content:center;
+  cursor:pointer;
+  transition:background .2s ease, border-color .2s ease, color .2s ease;
+}
+.topbar__bell:hover,
+.topbar__bell:focus-visible{
+  background:rgba(255,255,255,.22);
+  border-color:rgba(255,255,255,.55);
+  outline:none;
+}
+.topbar__bell i{ font-size:18px; }
+.topbar__badge{
+  position:absolute;
+  top:6px; right:6px;
+  transform:translate(40%, -40%);
+  min-width:18px; height:18px;
+  border-radius:999px;
+  background:#f87171;
+  color:#fff;
+  font-size:10px;
+  font-weight:800;
+  display:inline-flex; align-items:center; justify-content:center;
+  padding:0 5px;
+  box-shadow:0 0 0 2px rgba(179,0,0,.35);
+}
+.topbar__badge[hidden]{ display:none; }
+.topbar-notification-panel{
+  position:absolute;
+  top:calc(100% + 10px);
+  right:0;
+  width:260px;
+  max-height:320px;
+  background:#fff;
+  color:#1f2937;
+  border-radius:14px;
+  box-shadow:0 18px 38px rgba(15,20,36,.18);
+  border:1px solid rgba(15,23,42,.12);
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  z-index:1500;
+}
+.topbar-notification-panel[aria-hidden="true"]{ display:none; }
+.topbar-notification-panel__empty{
+  margin:0;
+  font-size:13px;
+  color:#475569;
+}
 .logo{ display:flex; align-items:center; gap:10px; min-width:0; }
 .logo__mark{ width:28px; height:28px; border-radius:50%; background:#fff; flex:0 0 28px; }
 .logo__text{ font-weight:800; color:#fff; max-width:200px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }


### PR DESCRIPTION
## Summary
- add a notification bell dropdown to the main topbar with accessible styling and scripting
- reveal the Omega notification center and relax the standalone layout so the ticket list can display at least fifteen rows without its own scrollbar

## Testing
- Manual verification in browser (omega.html)


------
https://chatgpt.com/codex/tasks/task_e_68da071991c08331b4e579eafe624ca8